### PR TITLE
Fix meals page bottom padding

### DIFF
--- a/src/pages/meals/meals.module.scss
+++ b/src/pages/meals/meals.module.scss
@@ -12,7 +12,7 @@
 }
 
 .meals__page {
-	padding: 5rem 0;
+	padding: 5rem 0 20rem;
 }
 
 .text {


### PR DESCRIPTION
# Description
This PR fixes an issue where the footer was overlapping the meals.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
